### PR TITLE
fix: use persistent SQLite database file instead of in-memory database

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,14 @@ app.use(express.json());
 app.use(express.static(path.join(__dirname, 'client', 'build')));
 
 // Database connection
-const db = new sqlite3.Database(':memory:');
+const db = new sqlite3.Database('expenses.db', (err) => {
+  if (err) {
+    console.error('Error opening database:', err);
+  } else {
+    console.log('Connected to SQLite database');
+    initializeDB();
+  }
+});
 
 // Initialize database
 const initializeDB = () => {
@@ -36,8 +43,6 @@ const initializeDB = () => {
     stmt.finalize();
   });
 };
-
-initializeDB();
 
 // API Routes
 app.get('/api/expenses', (req, res) => {


### PR DESCRIPTION
Changed SQLite database from in-memory to persistent file storage to prevent data loss and fix loading issues.

Changes made:
- Switched from in-memory SQLite database to file-based storage
- Added error handling for database connection
- Ensures data persists between server restarts